### PR TITLE
Added "offline.html"

### DIFF
--- a/src/main/java/org/vaadin/paul/spring/app/security/SecurityConfiguration.java
+++ b/src/main/java/org/vaadin/paul/spring/app/security/SecurityConfiguration.java
@@ -86,7 +86,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				// web application manifest
 				"/manifest.webmanifest",
 				"/sw.js",
-				"/offline-page.html",
+				"/offline.html", // pwa default offline page
+				"/offline-page.html", // pwa offline page bakery example
 
 				// icons and images
 				"/icons/**",


### PR DESCRIPTION
Default name for offline page in our pwa config is "offline.html". The other one seems to be from the bakey example. Leads to issues with incognito mode and testbench, when logging in.